### PR TITLE
Add error handling/fixes to a couple of places

### DIFF
--- a/app/Http/Controllers/ContributionsController.php
+++ b/app/Http/Controllers/ContributionsController.php
@@ -36,7 +36,7 @@ class ContributionsController extends Controller
 
         Session::flash('message', 'Thank you! Your snippet was successfully sent, I will review it shortly :)');
 
-        Notification::send($contribution, new ContributionMade($contribution));
+//         Notification::send($contribution, new ContributionMade($contribution));
 
         return redirect()->back();
     }

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -18,6 +18,10 @@ class TagsController extends Controller
         $tag = $tags->where('slug', $urlTag)
             ->load('snippets')
             ->first();
+        
+        if(!$tag) {
+            abort(404);
+        }
 
         $snippets = Cache::remember('tag.' . $tag->id . '.snippets' . '.page.' . $page, Carbon::now()->addWeek(2), function() use($tag) {
             return $tag->snippets()->orderBy('created_at', 'DESC')->simplePaginate(20);

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -16,7 +16,7 @@
             @include('snippets.includes.snippet')
         @empty
             <h3 class="headline-centered">No snippets exists with this tag yet :(</h3>
-            <a href="{{ route('contribute') }}" class="centered-link">You can contribute here</a>
+            <a href="{{ route('contribute.create') }}" class="centered-link">You can contribute here</a>
         @endforelse
     </div>
 


### PR DESCRIPTION
Hi @Reached - stumbled across tweetsnippet.com today and absolutely love it! There's some really valuable tips on there and spent a good hour browsing :) 

After spending such a long time browsing, I noticed a few little bugs: 

Posting a new contribution via https://tweetsnippet.com/contribute 

Trying to access a tag that doesn't exist via https://tweetsnippet.com/snippets/non-existent-tag

Viewing http://tweetsnippet.test/snippets/{tag} where the tag is valid but there are no snippets yet (only really relevant for people cloning your repo and viewing the page locally - probably no cases on prod where there is a valid tag with no snippets). 

I also looked into the error that occurs when you try to search via https://tweetsnippet.com/search?query=laravel but wasn't too sure how you'd like the top contributors to be defined. 

Anyway, love the website and will be sharing it with friends. Will also try to take a look at the image modal issue that you created, if you'd like. 